### PR TITLE
Update nix documentation the README

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,19 +14,15 @@ If you _really_ cannot use Nix and still want to contribute, then xref:develop-w
 
 === Installing and setting up Nix
 
-This repository uses nix to provide the development and build environment.
+This repository uses Nix to provide the development and build environment.
 
-If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
-the flake config values to enable access to our binary caches.   
+For instructions on how to install and configure Nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document]. 
 
-The nix code is based on a template from the 
-link:https://github.com/input-output-hk/iogx/[IOGX flake]
-For instructions on how to install and configure nix (including how to enable 
-access to our binary caches), and how keep the flake inputs up to date, refer to 
-link:https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix[this section]
-of the IOGX manual.
+If you already have Nix installed and configured, you may enter the development shell by running `nix develop`.
 
-If you are committing code outside nix develop, you will get this error:
+=== Note on pre-commit hooks
+
+If you are committing code outside `nix develop`, you will get this error:
 
 ----
 pre-commit not found. Did you forget to activate your virtualenv?

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,88 +14,17 @@ If you _really_ cannot use Nix and still want to contribute, then xref:develop-w
 
 === Installing and setting up Nix
 
-This project uses Flakes, so you must have Nix version `>= 2.4` installed.
+This repository uses nix to provide the development and build environment.
 
-Either upgrade or install https://nixos.org/[Nix] following the instructions on https://nixos.org/download.html[its website].
+If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
+the flake config values to enable access to our binary caches.   
 
-On Linux this command should suffice: `sh <(curl -L https://nixos.org/nix/install) --daemon`
-
-=== How to get a shell environment with tools
-
-To enter the development shell run the following command in the root directory:
-
-`nix develop`
-
-If you receive this message:
-
-`error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override`
-
-Then try this:
-
-`nix develop --extra-experimental-features 'nix-command flakes'`
-
-You may now choose to edit your `/etc/nix/nix.conf` (global) or `~/.config/nix/nix.conf` (you must be a https://nixos.org/nix/manual/#ssec-multi-user[trusted user] to do this) by appending the following line:
-
-`extra-experimental-features = nix-command flakes`
-
-If you do so you will be able to enter the development shell by running `nix develop`.
-
-If you are a VSCode user, you may want to start your development session by running:
-
-`nix develop --command code`
-
-If this is your first time running `nix develop`, you may be asked the following:
-```
-do you want to allow configuration setting 'allow-import-from-derivation' to be set to 'true' (y/N)? y
-do you want to permanently mark this value as trusted (y/N)? y
-```
-Please type `y` to this and all subsequent prompts to make life easy for yourself.
-
-IMPORTANT: *It is particularly important to accept the `extra-substituters` and `extra-trusted-public-keys` settings, which will grant access to our Nix binary cache.*
-
-At this point and if this is your first time running `nix develop` then Nix will download, build and install a copious amout of dependencies.
-
-It is not uncommon for this process to take a couple of hours and to write tens of GBs to the `/nix/store`.
-
-*Rest assured that this only happens the very first time you run `nix develop`.*
-
-However you should pay attention to the output of `nix develop`: if you notice that you are _building_ GHC, it is likely that your caches have not been configured correctly.
-
-Accepting the configuration settings as outlined above should be sufficient to avoid this, however if your caches are still broken, you may try to append the following lines to `/etc/nix/nix.conf` and/or `~/.config/nix/nix.conf`:
-
-----
-substituters = https://cache.iog.io https://cache.nixos.org/
-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-extra-experimental-features = nix-command flakes
-----
-
-On NixOS, set the following NixOS options:
-----
-nix = {
-  binaryCaches          = [ "https://cache.iog.io" ];
-  binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
-};
-----
-
-You will need to restart the nix-daemon on non-NixOS for the changes to take effect, or just restart your machine.
-
-IMPORTANT: If you are on NixOS or otherwise using a multi-user Nix install, you **must** be a trusted user to set substituters. If you are not a trusted user, enabling the options prompted by the flake will have no effect (non-trusted users are disallowed from doing this).
-
-On non-NixOS systems, add the following to the system-wide configuration (`/etc/nix/nix.conf`):
-
-```
-trusted-users = <username> root
-```
-
-You can also use a group name by prefixing it with `@`, e.g. to add all members of the `wheel` group:
-
-```
-trusted-users = @wheel root
-```
-
-On NixOS, add the user/group name to the list under [`nix.settings.trusted-users`](https://search.nixos.org/options?show=nix.settings.trusted-users).
-
-=== Note on pre-commit hooks
+The nix code is based on a template from the 
+link:https://github.com/input-output-hk/iogx/[IOGX flake]
+For instructions on how to install and configure nix (including how to enable 
+access to our binary caches), and how keep the flake inputs up to date, refer to 
+link:https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix[this section]
+of the IOGX manual.
 
 If you are committing code outside nix develop, you will get this error:
 
@@ -189,7 +118,7 @@ Note that `cabal` itself keeps track of what index states it knows about, so whe
 The Nix code which builds our packages also cares about the index state.
 This is represented by some pinned inputs in our flake (see xref:update-nix-pins[here] for more details)
 You can update these by running:
-- `nix flake lock --update-input hackage-nix` for Hackage
+- `nix flake lock --update-input hackage` for Hackage
 - `nix flake lock --update-input CHaP` for CHaP
 
 After updating these, you should also consider updating `haskell.nix` with `nix flake lock --update-input haskell-nix` (although that is not mandatory).
@@ -202,7 +131,7 @@ In particular, we should not release our packages while we depend on a `source-r
 
 If we are stuck in a situation where we need a long-running fork of a package, we should release it to CHaP instead (see the https://github.com/input-output-hk/cardano-haskell-packages[CHaP README] for more).
 
-If you do add a `source-repository-package`, you need to update the `sha256` mapping in `nix/haskell-project.nix`.
+If you do add a `source-repository-package`, you need to update the `sha256` mapping in `nix/project.nix`.
 For the moment you have to do this by hand, using the following command to get the sha: `nix-prefetch-git --quiet <repo-url> <rev> | jq .sha256`, or by just getting it wrong and trying to build it, in which case Nix will give you the right value.
 
 [[update-nix-pins]]
@@ -226,8 +155,8 @@ You will get the latest revision for *all* your flake inputs (similar to what `n
 [[update-ghc]]
 === How to upgrade GHC
 
-Refer to the `haskellCompilers
-<https://github.com/input-output-hk/iogx#323-haskellcompilers>` field in IOGX to learn how to use a different compiler.
+Refer to the `mkHaskellProject
+<https://github.com/input-output-hk/iogx/blob/main/doc/api.md#mkhaskellproject>` function in IOGX to learn how to use a different compiler.
 
 Afterwards, you need to restart your Nix shell.
 
@@ -291,7 +220,7 @@ you will also need to pull in the Nix equivalent of the newer
 <https://github.com/input-output-hk/iogx#312-inputs>`in IOGX's documentation
 to learn how to update ``hackage.nix``.
 
-You can do this by running ``nix flake lock --update-input hackage-nix``.
+You can do this by running ``nix flake lock --update-input hackage``.
 
 ==== ... from the Cardano package repository
 

--- a/doc/read-the-docs-site/README.md
+++ b/doc/read-the-docs-site/README.md
@@ -6,11 +6,13 @@ Run `nix develop` to enter a development shell with `sphinx-build` and `sphinx-a
 
 The following commands are also available:
 
-- `build-readthedocs-site`
-  Build the docs locally in `_build/index.html`
-- `serve-readthedocs-site`
+- `develop-rtd-site`          
   Start a development server with live reload on `http://localhost:8000`
+- `build-rtd-site`             
+  Build the docs locally in `_build/index.html`
+- `serve-rtd-site`   
+  Build the full site with nix (including Haddock) and serve it on `http://localhost:8002`
 
-The doc site from main is built automatically and hosted [here](https://cardano-node-emulator.readthedocs.io).
+The doc site from main is built automatically and hosted [here](https://cardano-node-emulator.readthedocs.io/en/latest).
 
 Additionally, the site is built for all PRs, and a link to a preview can be found in the PR statuses.

--- a/flake.lock
+++ b/flake.lock
@@ -1441,11 +1441,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699460731,
-        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
+        "lastModified": 1699537966,
+        "narHash": "sha256-MGGza+vZDRjKj31WhQJDt7CqVVdrFkgkXIcqr0gDiU8=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
+        "rev": "c6ce7f034717ed0c0e9c6dd8fa2f898a15439627",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1436,15 +1436,16 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1698065888,
-        "narHash": "sha256-5MC+MsarxLwlJsI+Rwm29OfNL/ph4aqiNRWBZ9sB1wM=",
+        "lastModified": 1699460731,
+        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "81476eb708f525324050f03cd1cf064ba80e02fc",
+        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
         "type": "github"
       },
       "original": {
@@ -2094,6 +2095,22 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -2567,7 +2584,7 @@
         "flake-utils": "flake-utils_10",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_11",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1696846637,


### PR DESCRIPTION
Instructions on how to install & upgrade nix and how to setup the binary caches are now included in the [relevant section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix) of the IOGX manual. 
This PR updates various files and documents that reference nix. 
